### PR TITLE
Pin more-itertools to a version compatible with py2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "ukpostcodeparser>=1.1.1",
         "mock",
         "pytest>=3.8.0,<3.9",
+        "more-itertools<6.0.0",
     ],
     extras_require={
         ':python_version=="2.7"': [


### PR DESCRIPTION
### What does this changes

Force setup.py to install a version of more-itertools compatible with python 2.7

### What was wrong

Current test suite is failing for python 2.7, due to the fact that more_itertools (installed by pytest) dropped support for it, see https://github.com/erikrose/more-itertools/issues/253

### How this fixes it

Add `more-itertools<6.0.0` to `tests_require` in faker's setup.py
